### PR TITLE
도커파일의 빌드 환경 및 JDK 설정 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,37 @@
 # -------- Build stage --------
-FROM gradle:8.5-jdk21-alpine AS build
+FROM debian:12-slim AS build
 WORKDIR /app
-COPY . .
-RUN gradle clean bootJar -x test
+
+# OpenJDK 21 설치
+RUN apt-get update && apt-get install -y \
+    openjdk-21-jdk \
+    && rm -rf /var/lib/apt/lists/*
+
+# 프로젝트 파일 복사
+COPY gradlew .
+COPY gradle gradle
+COPY build.gradle.kts .
+COPY settings.gradle.kts .
+
+# gradlew 실행 권한 부여
+RUN chmod +x gradlew
+
+# 의존성 다운로드 (캐싱 최적화)
+RUN ./gradlew dependencies --no-daemon
+
+# 소스코드 복사 및 빌드
+COPY src src
+RUN ./gradlew clean bootJar -x test --no-daemon
 
 # -------- Runtime stage (JRE 21) --------
-FROM eclipse-temurin:21-jre-alpine
+FROM debian:12-slim
 WORKDIR /app
+
+# OpenJDK 21 JRE 설치
+RUN apt-get update && apt-get install -y \
+    openjdk-21-jre-headless \
+    && rm -rf /var/lib/apt/lists/*
+
 COPY --from=build /app/build/libs/*.jar app.jar
 EXPOSE 8080
 ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,20 +10,7 @@ RUN apt-get update && apt-get install -y \
     openjdk-21-jdk \
     && rm -rf /var/lib/apt/lists/*
 
-# 프로젝트 파일 복사
-COPY gradlew .
-COPY gradle gradle
-COPY build.gradle.kts .
-COPY settings.gradle.kts .
-
-# gradlew 실행 권한 부여
-RUN chmod +x gradlew
-
-# 의존성 다운로드 (캐싱 최적화)
-RUN ./gradlew dependencies --no-daemon
-
-# 소스코드 복사 및 빌드
-COPY src src
+COPY . .
 RUN ./gradlew clean bootJar -x test --no-daemon
 
 # -------- Runtime stage (JRE 21) --------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # -------- Build stage --------
-FROM debian:12-slim AS build
+FROM ubuntu:24.04 AS build
 WORKDIR /app
+
+# 시간대 설정 (상호작용 방지)
+ENV DEBIAN_FRONTEND=noninteractive
 
 # OpenJDK 21 설치
 RUN apt-get update && apt-get install -y \
@@ -24,8 +27,11 @@ COPY src src
 RUN ./gradlew clean bootJar -x test --no-daemon
 
 # -------- Runtime stage (JRE 21) --------
-FROM debian:12-slim
+FROM ubuntu:24.04
 WORKDIR /app
+
+# 시간대 설정 (상호작용 방지)
+ENV DEBIAN_FRONTEND=noninteractive
 
 # OpenJDK 21 JRE 설치
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
## 변경 내용

* Dockerfile에 os base image를 추가하여 환경에 상관 없이 빌드되도록 수정
* 혹시 모를 라이선스 이슈를 대비하여 jdk 변경: gradle:8.5-jdk21-alpine -> openjdk-21-jdk

podman 으로 실행 시 

```sh
podman-compose up --build
```

혹은 

```sh
podman build --format docker --tag=wordle-backend:latest
podman run --name wordle-backend -p 8080:8080/tcp localhost/wordle-backend:latest
```