### PR TITLE
JWT 키스토어 상대 경로 및 별칭 불일치 문제 해결

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,9 +46,9 @@ services:
       AWS_PROD_DB_PASSWORD: ${AWS_PROD_DB_PASSWORD:-}
       
       # JWT 설정
-      JWT_KEYSTORE_LOCATION: ${JWT_KEYSTORE_LOCATION:-classpath:keystore.p12}
+      JWT_KEYSTORE_LOCATION: ${JWT_KEYSTORE_LOCATION:-classpath:keys/keystore.p12}
       JWT_KEYSTORE_PASSWORD: ${JWT_KEYSTORE_PASSWORD:-changeit}
-      JWT_KEYSTORE_ALIAS: ${JWT_KEYSTORE_ALIAS:-wordle-jwt}
+      JWT_KEYSTORE_ALIAS: ${JWT_KEYSTORE_ALIAS:-oauth-key}
       
       # entrypoint.sh 스크립트용 키스토어 설정
       KEYSTORE_PATH: ${KEYSTORE_PATH:-/workspace/src/main/resources/keys/keystore.p12}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -38,9 +38,9 @@ spring:
       authorizationserver:
         jwt:
           keystore:
-            location: ${JWT_KEYSTORE_LOCATION:classpath:keystore.p12}
+            location: ${JWT_KEYSTORE_LOCATION:classpath:keys/keystore.p12}
             password: ${JWT_KEYSTORE_PASSWORD:changeit}
-            alias: ${JWT_KEYSTORE_ALIAS:wordle-jwt}
+            alias: ${JWT_KEYSTORE_ALIAS:oauth-key}
 
 management:
   endpoints:

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -45,9 +45,9 @@ spring:
       authorizationserver:
         jwt:
           keystore:
-            location: ${JWT_KEYSTORE_LOCATION:classpath:keystore.p12}
+            location: ${JWT_KEYSTORE_LOCATION:classpath:keys/keystore.p12}
             password: ${JWT_KEYSTORE_PASSWORD:changeit}
-            alias: ${JWT_KEYSTORE_ALIAS:wordle-jwt}
+            alias: ${JWT_KEYSTORE_ALIAS:oauth-key}
 
 # 프로덕션 환경 모니터링 설정 (보안 강화)
 management:

--- a/src/main/resources/application-test.yml
+++ b/src/main/resources/application-test.yml
@@ -38,9 +38,9 @@ spring:
       authorizationserver:
         jwt:
           keystore:
-            location: ${JWT_KEYSTORE_LOCATION:classpath:keystore.p12}
+            location: ${JWT_KEYSTORE_LOCATION:classpath:keys/keystore.p12}
             password: ${JWT_KEYSTORE_PASSWORD:changeit}
-            alias: ${JWT_KEYSTORE_ALIAS:wordle-jwt}
+            alias: ${JWT_KEYSTORE_ALIAS:oauth-key}
 
 # 테스트 환경 모니터링 설정
 management:


### PR DESCRIPTION
## 문제상황
Docker 환경에서 JWT 키스토어 별칭 불일치로 인한 OAuth2 인증 서버 시작 실패 문제

## 변경사항
- application-dev.yml, application-test.yml, application-prod.yml, docker-compose.yml에서 JWT 키스토어 별칭과 상대 경로 기본값을 entrypoint.sh 스크립트에 의한 값과 통일된 값으로 변경

## 수정된 파일
- src/main/resources/application-dev.yml
- src/main/resources/application-test.yml  
- src/main/resources/application-prod.yml
- docker-compose.yml

## 해결결과
- Spring Boot가 동일한 별칭과 상대 경로로 키 검색
- OAuth2 인증 서버 정상 시작 가능